### PR TITLE
Fix mixin

### DIFF
--- a/src/css/Button.less
+++ b/src/css/Button.less
@@ -94,7 +94,7 @@ button.skin-spring-button {
 
 .skin-spring-add-button {
     .linear-gradient-background-with-image (
-        top, #6cbb4c, #519c30, "esui-button-plus.gif", 9px, center, #65b445);
+        top, #6cbb4c, #519c30, "../img/esui-button-plus.gif", 9px, center, #65b445);
     padding: 0 13px 0 27px;
 }
 
@@ -107,7 +107,7 @@ button.skin-spring-button {
 }
 .skin-spring-add-button:active {
     .linear-gradient-background-with-image (
-        top, #519c30, #6cbb4c, "esui-button-plus.gif", 9px, center, #65b445);
+        top, #519c30, #6cbb4c, "../img/esui-button-plus.gif", 9px, center, #65b445);
 }
 
 .skin-spring-button:hover,
@@ -119,18 +119,18 @@ button.skin-spring-button {
 /** 下载系列 */
 .skin-download-button {
     .linear-gradient-background-with-image (
-        top, #FFF, #f6f6f6, "esui-btn-download.png", 40px, center, #65b445);
+        top, #FFF, #f6f6f6, "../img/esui-btn-download.png", 40px, center, #65b445);
     padding-left: 12px;
     padding-right: 25px;
 }
 .skin-download-button:active {
     .linear-gradient-background-with-image (
-        top, #f6f6f6, #FFF, "esui-btn-download.png", 40px, center, #65b445);
+        top, #f6f6f6, #FFF, "../img/esui-btn-download.png", 40px, center, #65b445);
 }
 
 /** 关闭layer按钮 */
 .skin-layerClose-button {
-    .background("esui.png", repeat, -37px, -88px, transparent);
+    .background("../img/esui.png", repeat, -37px, -88px, transparent);
     border: 0 none;
     height: 12px;
     overflow: hidden;
@@ -141,7 +141,7 @@ button.skin-spring-button {
     padding: 0;
 }
 .skin-layerClose-button:active {
-    .background("esui.png", repeat, -37px, -88px, transparent);
+    .background("../img/esui.png", repeat, -37px, -88px, transparent);
     border: 1px solid #f6f6f6;
     height: 12px;
     width: 12px;

--- a/src/css/Calendar.less
+++ b/src/css/Calendar.less
@@ -38,7 +38,7 @@
     margin-top: 3px;
     width: 16px;
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-cal.png", left, 0px, #f3f3f3);
+        top, #ffffff, #f6f6f6, "../img/esui-cal.png", left, 0px, #f3f3f3);
 }
 .ui-calendar-layer {
     background: #fff;
@@ -65,7 +65,7 @@
     margin-top: 5px;
 }
 .ui-calendar-validity-label-invalid {
-    .background('esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
+    .background('../img/esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
     border: 1px solid #F0CCCC;
     color: #dd6767;
     padding-left: 50px;

--- a/src/css/CommandMenu.less
+++ b/src/css/CommandMenu.less
@@ -9,7 +9,7 @@
 @import "variable.less";
 .ui-commandmenu {
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -6px, #fff);
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -6px, #fff);
     border: 1px solid #D8D8D8;
     border-radius: 3px 3px 3px 3px;
     .interactive-cursor ();
@@ -23,13 +23,13 @@
     &:hover,
 	&:focus {
     	.linear-gradient-background-with-image (
-       		top, #ffffff, #f6f6f6, "esui-combo-arrow.png",
+       		top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png",
             right, -36px, #f3f3f3);
 	}
 
 	&:active {
     	.linear-gradient-background-with-image (
-       		top, #f6f6f6, #ffffff, "esui-combo-arrow.png",
+       		top, #f6f6f6, #ffffff, "../img/esui-combo-arrow.png",
             right, -36px, #f3f3f3);
 	}
 }
@@ -38,7 +38,7 @@
 .ui-commandmenu-active:hover,
 .ui-commandmenu-active:focus {
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png",
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png",
         right, -69px, #f3f3f3);
 }
 
@@ -89,6 +89,6 @@
     &:focus,
     &:active {
         .linear-gradient-background-with-image (
-            top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -6px, #fff);
+            top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -6px, #fff);
     }
 }

--- a/src/css/Dialog.less
+++ b/src/css/Dialog.less
@@ -19,7 +19,7 @@
 }
 
 .ui-dialog-head-mixin {
-    .background("esui-dialog-head-bg.png", repeat);
+    .background("../img/esui-dialog-head-bg.png", repeat);
     color: #FFFFFF;
     font-weight: bold;
     height: 26px;
@@ -31,7 +31,7 @@
 }
 
 .ui-dialog-close-icon-mixin {
-    .background("esui-dialog-head-close.png");
+    .background("../img/esui-dialog-head-close.png");
     height: 13px;
     width: 13px;
     position: absolute;
@@ -158,7 +158,7 @@
     }
 
     .ui-dialog-icon-warning {
-        .background("esui-dialog-notice.png");
+        .background("../img/esui-dialog-notice.png");
         display: block;
         float: left;
         height: 22px;
@@ -168,7 +168,7 @@
     }
 
     .ui-dialog-icon-confirm {
-        .background("esui-dialog-question.png");
+        .background("../img/esui-dialog-question.png");
         display: block;
         float: left;
         height: 34px;

--- a/src/css/MonthView.less
+++ b/src/css/MonthView.less
@@ -24,14 +24,14 @@
 /** 先前向后按钮 */
 .ui-monthview-month-forward,
 .ui-monthview-month-back {
-    .background("esui.png", repeat, 0px, -200px);
+    .background("../img/esui.png", repeat, 0px, -200px);
     font-size: 1px;
     height: 20px;
     width: 20px;
     padding: 0;
     float: left;
     &:active {
-        .background("esui.png", repeat, 0px, -200px);
+        .background("../img/esui.png", repeat, 0px, -200px);
         height: 20px;
     }
 }
@@ -150,7 +150,7 @@
     .ui-monthview-month-back {
         background-position: 0 -240px; 
         &:active {
-            .background("esui.png", repeat, 0px, -240px);
+            .background("../img/esui.png", repeat, 0px, -240px);
             height: 20px;
             border-color: #CFCFCF;
         }

--- a/src/css/RangeCalendar.less
+++ b/src/css/RangeCalendar.less
@@ -38,7 +38,7 @@
     margin-right: 5px;
     width: 16px;
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png", left, -9px, #f3f3f3);
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", left, -9px, #f3f3f3);
 }
 
 .ui-rangecalendar-layer {
@@ -153,7 +153,7 @@
     margin-top: 5px;
 }
 .ui-rangecalendar-validity-label-invalid {
-    .background('esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
+    .background('../img/esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
     border: 1px solid #F0CCCC;
     color: #dd6767;
     padding-left: 50px;

--- a/src/css/Region.less
+++ b/src/css/Region.less
@@ -164,7 +164,7 @@
     margin-top: 5px;
 }
 .ui-region-validity-label-invalid {
-    .background('esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
+    .background('../img/esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
     border: 1px solid #F0CCCC;
     color: #dd6767;
     padding-left: 50px;

--- a/src/css/Select.less
+++ b/src/css/Select.less
@@ -9,7 +9,7 @@
 @import "variable.less";
 .ui-select {
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -6px, #fff);
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -6px, #fff);
     .ellipse-overflow ();
     .interactive-cursor ();
     border: 1px solid #D8D8D8;
@@ -26,19 +26,19 @@
 .ui-select:hover,
 .ui-select:focus {
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -36px, #fff);
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -36px, #fff);
 }
 
 .ui-select:active {
     .linear-gradient-background-with-image (
-        top, #f6f6f6, #ffffff, "esui-combo-arrow.png", right, -36px, #fff);
+        top, #f6f6f6, #ffffff, "../img/esui-combo-arrow.png", right, -36px, #fff);
 }
 
 .ui-select-active,
 .ui-select-active:hover,
 .ui-select-active:focus {
     .linear-gradient-background-with-image (
-        top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -67px, #fff);
+        top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -67px, #fff);
 }
 
 .ui-select-layer {
@@ -94,7 +94,7 @@
     &:hover,
     &:focus {
         .linear-gradient-background-with-image (
-            top, #ffffff, #f6f6f6, "esui-combo-arrow.png", right, -6px, #f3f3f3);
+            top, #ffffff, #f6f6f6, "../img/esui-combo-arrow.png", right, -6px, #f3f3f3);
     }
 }
 
@@ -107,7 +107,7 @@
     margin-top: 5px;
 }
 .ui-select-validity-label-invalid {
-    .background('esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
+    .background('../img/esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
     border: 1px solid #F0CCCC;
     color: #dd6767;
     padding-left: 50px;

--- a/src/css/TextLine.less
+++ b/src/css/TextLine.less
@@ -65,7 +65,7 @@
     margin-top: 5px;
 }
 .ui-textline-validity-label-invalid {
-    .background('esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
+    .background('../img/esui-icon-alert.png', no-repeat, 15px, center, #FEDBDC);
     border: 1px solid #F0CCCC;
     color: #dd6767;
     padding-left: 50px;

--- a/src/css/Tip.less
+++ b/src/css/Tip.less
@@ -43,7 +43,7 @@ ui
 
 .ui-tip-arrow-tl .ui-tip-arrow-1 {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -24px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -24px, -12px);
     width: 12px;
     height: 13px;
     top: -13px;
@@ -51,7 +51,7 @@ ui
 }
 .ui-tip-arrow-tr {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -36px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -36px, -12px);
     width: 12px;
     height: 13px;
     top: -13px;
@@ -59,7 +59,7 @@ ui
 }
 .ui-tip-arrow-bl {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -12px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -12px, -12px);
     width: 12px;
     height: 13px;
     bottom: -13px;
@@ -67,7 +67,7 @@ ui
 }
 .ui-tip-arrow-br {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, 0px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, 0px, -12px);
     width: 12px;
     height: 13px;
     bottom: -13px;
@@ -76,7 +76,7 @@ ui
 
 .ui-tip-arrow-lt {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -26px, 0px);
+    .background ("../img/esui_transparent.gif", no-repeat, -26px, 0px);
     width: 13px;
     height: 12px;
     top: 7px;
@@ -84,7 +84,7 @@ ui
 }
 .ui-tip-arrow-lb {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -39px, 0);
+    .background ("../img/esui_transparent.gif", no-repeat, -39px, 0);
     width: 13px;
     height: 12px;
     bottom: 7px;
@@ -92,7 +92,7 @@ ui
 }
 .ui-tip-arrow-rt {
     display: block;
-    .background ("esui_transparent.gif");
+    .background ("../img/esui_transparent.gif");
     width: 13px;
     height: 12px;
     top: 7px;
@@ -100,7 +100,7 @@ ui
 }
 .ui-tip-arrow-rb {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -13px, 0);
+    .background ("../img/esui_transparent.gif", no-repeat, -13px, 0);
     width: 13px;
     height: 12px;
     bottom: 7px;
@@ -110,7 +110,7 @@ ui
 .ui-tip {
     width: 14px;
     height: 14px;
-    .background ("esui.png", no-repeat, -101px, -89px);
+    .background ("../img/esui.png", no-repeat, -101px, -89px);
     overflow: hidden;
     .inline-block ();
     vertical-align: middle;

--- a/src/css/TipLayer.less
+++ b/src/css/TipLayer.less
@@ -48,7 +48,7 @@
 
 .ui-tiplayer-arrow-tl .ui-tiplayer-arrow-1 {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -24px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -24px, -12px);
     width: 12px;
     height: 13px;
     top: -13px;
@@ -56,7 +56,7 @@
 }
 .ui-tiplayer-arrow-tr {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -36px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -36px, -12px);
     width: 12px;
     height: 13px;
     top: -13px;
@@ -64,7 +64,7 @@
 }
 .ui-tiplayer-arrow-bl {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -12px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, -12px, -12px);
     width: 12px;
     height: 13px;
     bottom: -13px;
@@ -72,7 +72,7 @@
 }
 .ui-tiplayer-arrow-br {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, 0px, -12px);
+    .background ("../img/esui_transparent.gif", no-repeat, 0px, -12px);
     width: 12px;
     height: 13px;
     bottom: -13px;
@@ -81,7 +81,7 @@
 
 .ui-tiplayer-arrow-lt {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -26px, 0px);
+    .background ("../img/esui_transparent.gif", no-repeat, -26px, 0px);
     width: 13px;
     height: 12px;
     top: 7px;
@@ -89,7 +89,7 @@
 }
 .ui-tiplayer-arrow-lb {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -39px, 0);
+    .background ("../img/esui_transparent.gif", no-repeat, -39px, 0);
     width: 13px;
     height: 12px;
     bottom: 7px;
@@ -97,7 +97,7 @@
 }
 .ui-tiplayer-arrow-rt {
     display: block;
-    .background ("esui_transparent.gif");
+    .background ("../img/esui_transparent.gif");
     width: 13px;
     height: 12px;
     top: 7px;
@@ -105,7 +105,7 @@
 }
 .ui-tiplayer-arrow-rb {
     display: block;
-    .background ("esui_transparent.gif", no-repeat, -13px, 0);
+    .background ("../img/esui_transparent.gif", no-repeat, -13px, 0);
     width: 13px;
     height: 12px;
     bottom: 7px;

--- a/src/css/Tree.less
+++ b/src/css/Tree.less
@@ -36,12 +36,12 @@
     width: 14px;
     height: 14px;
     overflow: hidden;
-    .background("esui-open-icon.png", no-repeat, 0, 0, transparent);
+    .background("../img/esui-open-icon.png", no-repeat, 0, 0, transparent);
 }
 
 // 展开
 .ui-tree-node-indicator-expanded {
-    .background("esui-close-icon.png", no-repeat, 0, 0, transparent);
+    .background("../img/esui-close-icon.png", no-repeat, 0, 0, transparent);
 }
 
 // 收起
@@ -89,7 +89,7 @@
 }
 
 .skin-folder-tree-node-indicator {
-    .background("esui-folder.png", no-repeat, 0, -6px, transparent);
+    .background("../img/esui-folder.png", no-repeat, 0, -6px, transparent);
 }
 .skin-folder-tree-node-indicator-expanded {
     background-position: 0 -30px;

--- a/src/css/mixin.less
+++ b/src/css/mixin.less
@@ -18,7 +18,17 @@
 
 // 背景函数
 .background (@image-url, @repeat-type:no-repeat, @s-x:0, @s-y:0, @b-color:transparent) {
-    background-image: url("@{base-url}@{image-url}");
+    @url: ~"@{image-url}";
+    @is-url-exp: ~`/^url\([^()]+\)$/i.test("@{url}") ? 'true' : 'false'`;
+
+    .background-image(@is-url-exp) when not (@is-url-exp) {
+        background-image: url(@url);
+    }
+    .background-image(@is-url-exp) when (@is-url-exp) {
+        background-image: @url;
+    }
+    .background-image(@is-url-exp);
+
     background-repeat: @repeat-type;
     background-position: @s-x @s-y;
     background-color: @b-color;
@@ -82,33 +92,61 @@
     @left: 0% 0%, 100% 0%;
     @bottom: 0% 100%, 0% 0%;
     @right: 100% 0%, 0% 0%;
-    background: 
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y @b-color;
 
-    // Safari 4-5, Chrome 1-9
-    background: 
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y,
-        -webkit-gradient(linear, @@direction, from(@from-color), to(@to-color));
-  
-    // Safari 5.1, Chrome 10+
-    background:
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y,
-        -webkit-linear-gradient(@direction, @from-color, @to-color);
-  
-    // Firefox 3.6+
-    background:
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y,
-        -moz-linear-gradient(@direction, @from-color, @to-color);
-  
-    // IE 10
-    background:
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y,
-        -ms-linear-gradient(@direction, @from-color, @to-color);
-  
-    // Opera 11.10+
-    background:
-        url("@{base-url}@{image-url}") @repeat-type scroll @s-x @s-y,
-        -o-linear-gradient(@direction, @from-color, @to-color);
+    @url: ~"@{image-url}";
+    @is-url-exp: ~`/^url\([^()]+\)$/i.test("@{url}") ? 'true' : 'false'`;
+
+    .background(@is-url-exp) when not (@is-url-exp) {
+        background: 
+            url(@url) @repeat-type scroll @s-x @s-y @b-color;
+        // Safari 4-5, Chrome 1-9
+        background: 
+            url(@url) @repeat-type scroll @s-x @s-y,
+            -webkit-gradient(linear, @@direction, from(@from-color), to(@to-color));
+        // Safari 5.1, Chrome 10+
+        background:
+            url(@url) @repeat-type scroll @s-x @s-y,
+            -webkit-linear-gradient(@direction, @from-color, @to-color);
+        // Firefox 3.6+
+        background:
+            url(@url) @repeat-type scroll @s-x @s-y,
+            -moz-linear-gradient(@direction, @from-color, @to-color);
+        // IE 10
+        background:
+            url(@url) @repeat-type scroll @s-x @s-y,
+            -ms-linear-gradient(@direction, @from-color, @to-color);
+        // Opera 11.10+
+        background:
+            url(@url) @repeat-type scroll @s-x @s-y,
+            -o-linear-gradient(@direction, @from-color, @to-color);
+    }
+
+    .background(@is-url-exp) when (@is-url-exp) {
+        background: 
+            @url @repeat-type scroll @s-x @s-y @b-color;
+        // Safari 4-5, Chrome 1-9
+        background: 
+            @url @repeat-type scroll @s-x @s-y,
+            -webkit-gradient(linear, @@direction, from(@from-color), to(@to-color));
+        // Safari 5.1, Chrome 10+
+        background:
+            @url @repeat-type scroll @s-x @s-y,
+            -webkit-linear-gradient(@direction, @from-color, @to-color);
+        // Firefox 3.6+
+        background:
+            @url @repeat-type scroll @s-x @s-y,
+            -moz-linear-gradient(@direction, @from-color, @to-color);
+        // IE 10
+        background:
+            @url @repeat-type scroll @s-x @s-y,
+            -ms-linear-gradient(@direction, @from-color, @to-color);
+        // Opera 11.10+
+        background:
+            @url @repeat-type scroll @s-x @s-y,
+            -o-linear-gradient(@direction, @from-color, @to-color);
+    }
+
+    .background(@is-url-exp);
 }
 
 // CSS3 相关
@@ -221,6 +259,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    word-wrap: normal;
 }
 
 // 重设列表的样式

--- a/src/css/variable.less
+++ b/src/css/variable.less
@@ -3,7 +3,6 @@
 @default-font-size: 12px;
 @default-font-color: #666;
 @default-body-margin: 0;
-@base-url: "../img/";
 
 // z-index
 @layer-z-index: 1002;


### PR DESCRIPTION
当`lesscss`编译less，并且带有`relativeUrl=true`参数的时候（也就是edp-build的默认逻辑），当`less`中出现了`background: url(../../img/logo.gif)`，并且计算`img.gif`路径的时候，是以`url()`出现的文件为基准来计算的。

`esui`原来的实现方式，`.background`这个`mixin`，直接把`url()`写死到了`src/css/mixin.less`，这样子当调用`.background`这个`mixin`的时候，总是以`src/css/mixin.less`为基准来计算，这个其实是不对的。

例如：

``` css
/** src/biz/css/biz.less */
@import ../../../dep/esui/3.0.0/src/css/mixin.less
div {
  .background(../../img/logo.gif)
}
```

我们其实希望`../../img/logo.gif`的路径计算是参考`src/biz/css/biz.less`文件路径，而不是`src/css/mixin.less`文件路径。因此这个升级可以通过添加不同的参数来完成，例如：

``` css
/** src/biz/css/biz.less */
@import ../../../dep/esui/3.0.0/src/css/mixin.less
div {
  .background(url(../../img/logo.gif))
}
```
