### PR TITLE
Tip 当鼠标 mouseout Tip元素或者Tip浮层后，隐藏Tip浮层

### DIFF
--- a/demo/Tip.html
+++ b/demo/Tip.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <title>Button - ESUI Demo</title>
+        <title>Tip - ESUI Demo</title>
         <script src="loader/esl.js"></script>
         <script>
             require.config({
@@ -103,6 +103,15 @@
                     </h3>
                 </div>
             </div>
+            <div>
+                <h2>悬停展现，移出消失</h2>
+                <div>
+                    <h3>
+                        悬停展现，移出消失
+                        <div data-ui="type:Tip;id:over-tip-hide-on-out;title:悬停展现;content:悬停展现，移出消失展现内容;arrow:1;showMode:over;isHideOnOut:true"></div>
+                    </h3>
+                </div>
+            </div>            
         </div>
 
         <script>

--- a/src/Tip.js
+++ b/src/Tip.js
@@ -69,6 +69,16 @@ define(
                 showMode: 'over',
 
                 /**
+                 * @property {string} isHideOnOut
+                 *
+                 * 指定当鼠标移出Tip控件以及Tip浮层后，是否自动隐藏浮层。
+                 * 为了方便从DOM生成，此属性在初始化时如果为字符串`"false"`，
+                 * 将被认为是布尔值`false`处理。
+                 * 只有当showMode是over时才生效。
+                 */
+                isHideOnOut: false,
+
+                /**
                  * @property {number} delayTime
                  *
                  * 指定信息浮层的显示的延迟时间，以毫秒为单位，
@@ -86,6 +96,10 @@ define(
             };
             if (options.arrow === 'false') {
                 options.arrow = false;
+            }
+
+            if (options.isHideOnOut === 'false') {
+                options.isHideOnOut = false;
             }
 
             extractDOMProperties(this.main, properties);
@@ -140,6 +154,7 @@ define(
 
             var attachOptions = {
                 showMode: this.showMode,
+                isHideOnOut: this.isHideOnOut,
                 delayTime: +this.delayTime,
                 showDuration: +this.showDuration,
                 targetControl: this,

--- a/src/TipLayer.js
+++ b/src/TipLayer.js
@@ -369,15 +369,18 @@ define(
                 {
                     name: [
                         'targetDOM', 'targetControl',
-                        'showMode', 'positionOpt', 'delayTime', 'showDuration'
+                        'showMode', 'isHideOnOut', 'positionOpt', 'delayTime',
+                        'showDuration'
                     ],
                     paint:
                         function (tipLayer, targetDOM, targetControl,
-                            showMode, positionOpt, delayTime, showDuration) {
+                            showMode, isHideOnOut, positionOpt, delayTime,
+                            showDuration) {
                         var options = {
                             targetDOM: targetDOM,
                             targetControl: targetControl,
                             showMode: showMode,
+                            isHideOnOut: isHideOnOut,
                             delayTime: delayTime || DEFAULT_DELAY_SHOW,
                             showDuration: showDuration || DEFAULT_DELAY_HIDE
                         };
@@ -846,6 +849,24 @@ define(
                         options.positionOpt
                     )
                 );
+
+                // 如果设置了isHideOnOut，则mouseout this.main和mouseout
+                // targetElement的时候，隐藏浮层
+                var isHideOnOut = options.isHideOnOut;
+                if (isHideOnOut === true || isHideOnOut === 'true') {
+                    helper.addDOMEvent(
+                        this, handler.targetElement, 'mouseout',
+                        function () {
+                            handler.layer.hide();
+                        }
+                    );
+                    helper.addDOMEvent(
+                        this, this.main, 'mouseout',
+                        function () {
+                            handler.layer.hide();
+                        }
+                    );
+                }
             },
 
             /**


### PR DESCRIPTION
For Issue 353

为Tip增加一个Option，可以控制Tip mouseout Tip元素或者Tip浮层后，隐藏Tip浮层的行为。
增加了Demo演示这个Option。
顺便修改了Demo页的title。
