### PR TITLE
将 esui-label 的默认样式改为 inline

### DIFF
--- a/src/css/reset.less
+++ b/src/css/reset.less
@@ -65,9 +65,15 @@ address, caption, cite, code, dfn, em, strong, th, var, i {
 }
 
 esui- {
-    &calendar, &crumb, &dialog, &label, &month-view, &pager, &panel, &range-calendar,
+    &calendar, &crumb, &dialog, &month-view, &pager, &panel, &range-calendar,
     &region, &rich-calendar, &schedule, &search-box, &sidebar, &select, &tab, &table,
     &text-box, &text-line, &tip, &tip-layer, &tree, &wizard {
         display: block;
+    }
+}
+
+esui- {
+    &label {
+        display: inline;
     }
 }


### PR DESCRIPTION
将 `esui-label` 的默认样式改为 `inline`
