### PR TITLE
修改dom节点的text可以直接使用innerText属性

### DIFF
--- a/src/painters.js
+++ b/src/painters.js
@@ -200,7 +200,7 @@ define(
                         var html = typeof this.generate === 'function'
                             ? this.generate(control, value)
                             : value;
-                        element.innerHTML = u.escape(html || '');
+                            element.innerText = html || '';
                     }
                 }
             };


### PR DESCRIPTION
这里是否可以直接使用innerText属性，而不用对html值进行编码？
