### PR TITLE
Update children.js

### DIFF
--- a/src/helper/children.js
+++ b/src/helper/children.js
@@ -29,7 +29,7 @@ define(
             options.viewContext = this.control.viewContext;
             options.parent = this.control;
 
-            ui.init(wrap, options);
+            return ui.init(wrap, options);
         };
 
         /**


### PR DESCRIPTION
ui.init()中是会return controls的，我觉得这个地方也应该return出去，外部调用时可以方便地取到controls
