### PR TITLE
fix #527

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -164,6 +164,9 @@ define(
                 }
                 ui.init(main, options);
             });
+
+            // 直接追加到content属性，以防setContent时判断oldValue出现问题
+            this.content = isPrepend ? html + this.content : this.content + html;
         }
 
         /**


### PR DESCRIPTION
修复 #527 中提到的 `Panel` 控件在 `appendContent`/`prependContent` 时 `content` 属性没有修改导致 `setContent` 时判断旧值时可能出现问题。
