### PR TITLE
content改变时，刷新Dialog位置

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -240,6 +240,9 @@ define(
                             body.setContent(
                                 lib.format(bfTpl, data)
                             );
+                            if (dialog.isShow) {
+                                resizeHandler.apply(dialog);
+                            }
                         }
                     },
                     {


### PR DESCRIPTION
Dialog.alert和Dialog.confirm引入了rawContent字段，导致Dialog初始化和最终显示的内容不一样，从而导致Dialog高度不一致，如果不刷新Dialog位置，会导致最终Dialog无法垂直居中。
