### PR TITLE
修改两个样式配置来提升性能

### DIFF
--- a/src/css/Overlay.less
+++ b/src/css/Overlay.less
@@ -16,6 +16,7 @@
     &.@{ui-state-prefix}-hidden {
         display: block !important;
         left: -10000px !important;
+        visibility: hidden;
     }
 }
 

--- a/src/css/Tree.less
+++ b/src/css/Tree.less
@@ -31,7 +31,6 @@
 
 .@{ui-class-prefix}-tree-node {
     cursor: pointer;
-    overflow: hidden;
 }
 
 .@{ui-class-prefix}-tree-node-indicator {


### PR DESCRIPTION
1. Mac Chrome下发现树形控件外层容器的 `overflow:hidden` 样式会较大地影响渲染性能。同时发现这个样式是可以去掉的。
2. `Overlay` hidden时，将 `visibility` 置为 `hidden`，减少实际渲染开销
