### PR TITLE
BoxGroup bugfix

### DIFF
--- a/src/BoxGroup.js
+++ b/src/BoxGroup.js
@@ -245,9 +245,7 @@ define(
                     if (this.boxType === 'radio') {
                         return this.backwardCompatible ? [val] : val;
                     }
-                    else {
-                        return val ? val.split(',') : [];
-                    }
+                    return val ? val.split(',') : [];
                 },
 
                 /**
@@ -364,7 +362,9 @@ define(
                 .pluck('value')
                 .value();
 
-            this.rawValue = result;
+            this.rawValue = (!this.backwardCompatible && this.boxType === 'radio')
+                ? result[0]
+                : result;
             this.fire('change');
             this.fire('changed');
         }


### PR DESCRIPTION
修复boxType === 'radio' && backwardCompatible === false 时getRawValue仍为数组的bug
