### PR TITLE
添加几个创建控件的钩子

### DIFF
--- a/src/InputControl.js
+++ b/src/InputControl.js
@@ -379,7 +379,7 @@ define(
                             }
                             else {
                                 validityLabelRef = $(validityLabelRef);
-                            }    
+                            }
                         }
 
                         var ref = validityLabelRef ? validityLabelRef[0] : this.main;

--- a/src/lib/lang.js
+++ b/src/lib/lang.js
@@ -190,15 +190,14 @@ define(
          *
          * 本方法主要修正babel5升级到babel6后对export嵌套逻辑变更的问题
          *
-         * -与babel5相比，babel6转的话，default export会变成exports.default，
-         *  所以require('xxx')就要变成require('xxx').default
+         * 与babel5相比，babel6转的话，default export会变成exports.default，所以require('xxx')就要变成require('xxx').default
          *
          * @param {Object} exports babel6编译后的对象
-         * @param {Object} default对象
+         * @return {Object} default对象
         */
         lib.interopDefault = function (exports) {
             return exports.__esModule ? exports.default : exports;
-        }
+        };
 
         return lib;
     }


### PR DESCRIPTION
事情的起因是有时候我们除了全局的扩展和在模板里声明的扩展外，希望在初始化一个视图的时候可以再传一些通用的扩展（只有在初始化的时候才有足够的上下文创建这个扩展的实例），单/双向绑定如果通过扩展做就是这种情况

如果在`init`的`options`参数中再加上`extensions`属性自然可以解决这个问题，但考虑到有可能有更多的需要在`init`时期增加的逻辑，不如使用钩子的形式实现这一目的
