### PR TITLE
给 TextLine 添加 focus 状态

### DIFF
--- a/src/TextLine.js
+++ b/src/TextLine.js
@@ -62,6 +62,8 @@ define(
          * @ignore
          */
         function focus(e) {
+            this.addState('focus');
+
             togglePlaceholder(this, true);
 
             /**
@@ -81,6 +83,8 @@ define(
          * @ignore
          */
         function blur(e) {
+            this.removeState('focus');
+
             togglePlaceholder(this, false);
 
             /**


### PR DESCRIPTION
因为 `<textarea>` 在内部，想在 `:focus` 状态下加整个控件外框之类的样式的话，需要在外面搞个 state。类似 SearchBox。
