### PR TITLE
修复 3.1.0 -> 3.1.1 后使用自定义 regionData 会死循环的问题

### DIFF
--- a/src/Region.js
+++ b/src/Region.js
@@ -864,7 +864,7 @@ define(
                  * 默认选项配置
                  */
                 var properties = {
-                    regionData: lib.clone(Region.REGION_LIST),
+                    regionData: Region.REGION_LIST,
                     mode: 'multi',
                     pureSelect: false,
                     rawValue: []
@@ -873,6 +873,7 @@ define(
                 helper.extractValueFromInput(this, options);
 
                 lib.extend(properties, options);
+                properties.regionData = lib.clone(properties.regionData);
 
                 if (options.value) {
                     properties.rawValue = properties.value.split(',');


### PR DESCRIPTION
`Region`的数据一直有循环引用，`lib.clone`在`3.1.1`之后改为完全深复制，爆出这个问题。应该对`extend`后实际修改的`regionData`进行深复制